### PR TITLE
fixes for Prima 1.50

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -35,7 +35,7 @@ WriteMakefile1(
         },
     },
     
-    MIN_PERL_VERSION => '5.006',
+    MIN_PERL_VERSION => '5.010',
 
     ($eumm_version >= 6.3001
       ? ('LICENSE'=> 'perl')
@@ -49,10 +49,10 @@ WriteMakefile1(
     PREREQ_PM => {
         'Prima'              => 0,
         'AnyEvent'           => 0,
-        'Filter::signatures' => 0,
     },
     TEST_REQUIRES => {
-        'Test::More' => 0,
+        'Test::More'         => 0,
+        'AnyEvent::HTTP'     => 0,
     },
 
     dist                => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -47,7 +47,7 @@ WriteMakefile1(
     },
 
     PREREQ_PM => {
-        'Prima'              => 0,
+        'Prima'              => '1.50',
         'AnyEvent'           => 0,
     },
     TEST_REQUIRES => {

--- a/lib/AnyEvent/Impl/Prima.pm
+++ b/lib/AnyEvent/Impl/Prima.pm
@@ -46,6 +46,8 @@ sub io { my ($s,%r) = @_;
     $f
 } 
 
+sub AnyEvent::Impl::Prima::Timer::DESTROY { ${$_[0]}->destroy }
+
 sub timer { my ( $s, %r ) = @_;
     my($c,$g) = $r{cb};
     
@@ -60,9 +62,8 @@ sub timer { my ( $s, %r ) = @_;
     my %timer_params = (
         timeout => $next,
     );
-    my $res = Prima::Timer->new(
+    my $timer = Prima::Timer->new(
         timeout => $next,
-	owner   => undef,
         onTick  => sub {
             #warn "Timer $_[0] fired";
             if( $repeat ) {
@@ -78,8 +79,8 @@ sub timer { my ( $s, %r ) = @_;
         },
     );
     #warn "Starting new timer $res";
-    $res->start;
-    $res
+    $timer->start;
+    return bless \ $timer, "AnyEvent::Impl::Prima::Timer";
 }
 
 sub poll {

--- a/lib/AnyEvent/Impl/Prima.pm
+++ b/lib/AnyEvent/Impl/Prima.pm
@@ -62,6 +62,7 @@ sub timer { my ( $s, %r ) = @_;
     );
     my $res = Prima::Timer->new(
         timeout => $next,
+	owner   => undef,
         onTick  => sub {
             #warn "Timer $_[0] fired";
             if( $repeat ) {
@@ -86,9 +87,12 @@ sub poll {
     $::application->yield;
 }
 
+{
+no warnings 'redefine';
 sub AnyEvent::CondVar::Base::_wait {
     require Prima::Application;
     $::application->yield until exists $_[0]{_ae_sent};
+}
 }
 
 push @AnyEvent::REGISTRY,["Prima",__PACKAGE__]; 


### PR DESCRIPTION
Hi Max,

I finally could get onto the work, I think everything works now. The only problem is that I found the crash you were talking about AFTER releasing 1.50, and that beats the whole purpose of releasing the newer version that supports AE:I:P . So I had to resort to the trick with wrapping Timer into a pure-perl object, because the crash happened (on win32 only) when I used the newer, 1.50-specific code with (owner => undef). Ironically, AE:I:P will only work on 1.50, because it needs File.fd :) That problem is fixed, and will be out in 1.51, and then we can restore the (owner => undef) code.

But anyway it works now, and you're welcome to try and see if it works for you too.

Sincerely,
Dmitry